### PR TITLE
Add the Generate PDF button

### DIFF
--- a/app/Console/Commands/GeneratePlanner.php
+++ b/app/Console/Commands/GeneratePlanner.php
@@ -23,7 +23,7 @@ class GeneratePlanner extends Command
             ->showBackground()
             ->paperSize(596, 795, 'px')
             ->timeout(120)
-            ->save(storage_path('planner.pdf'));
+            ->save(storage_path('app/planner.pdf'));
 
         $this->info('Planner generated');
     }

--- a/app/Console/Commands/GeneratePlanner.php
+++ b/app/Console/Commands/GeneratePlanner.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands;
 
+use App\Jobs\GeneratePdf;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Storage;
 use Spatie\Browsershot\Browsershot;
@@ -14,17 +15,7 @@ class GeneratePlanner extends Command
 
     public function handle()
     {
-        // reMarkable screen size: https://support.remarkable.com/hc/en-us/articles/360006699557
-        // original tablet pixel size / table dpi * browser dpi
-        // 1404 / 226 * 96
-        // 1872 / 226 * 96
-
-        Browsershot::url(url('/all'))
-            ->setExtraHttpHeaders(['X-Printing-Pdf' => 'true'])
-            ->showBackground()
-            ->paperSize(596, 795, 'px')
-            ->timeout(120)
-            ->save(Storage::path('planner.pdf'));
+        GeneratePdf::dispatch();
 
         $this->info('Planner generated');
     }

--- a/app/Console/Commands/GeneratePlanner.php
+++ b/app/Console/Commands/GeneratePlanner.php
@@ -3,6 +3,7 @@
 namespace App\Console\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
 use Spatie\Browsershot\Browsershot;
 
 class GeneratePlanner extends Command
@@ -23,7 +24,7 @@ class GeneratePlanner extends Command
             ->showBackground()
             ->paperSize(596, 795, 'px')
             ->timeout(120)
-            ->save(storage_path('app/planner.pdf'));
+            ->save(Storage::path('planner.pdf'));
 
         $this->info('Planner generated');
     }

--- a/app/Http/Controllers/GeneratePdfController.php
+++ b/app/Http/Controllers/GeneratePdfController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+
+class GeneratePdfController extends Controller
+{
+    /**
+     * Handle the incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function __invoke(Request $request)
+    {
+        \Artisan::call('generate');
+
+        return Storage::download('planner.pdf');
+    }
+}

--- a/app/Http/Controllers/GeneratePdfController.php
+++ b/app/Http/Controllers/GeneratePdfController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Jobs\GeneratePdf;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 
@@ -9,7 +10,7 @@ class GeneratePdfController extends Controller
 {
     public function __invoke(Request $request)
     {
-        \Artisan::call('generate');
+        GeneratePdf::dispatch();
 
         return Storage::download('planner.pdf');
     }

--- a/app/Http/Controllers/GeneratePdfController.php
+++ b/app/Http/Controllers/GeneratePdfController.php
@@ -7,12 +7,6 @@ use Illuminate\Support\Facades\Storage;
 
 class GeneratePdfController extends Controller
 {
-    /**
-     * Handle the incoming request.
-     *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response
-     */
     public function __invoke(Request $request)
     {
         \Artisan::call('generate');

--- a/app/Jobs/GeneratePdf.php
+++ b/app/Jobs/GeneratePdf.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Storage;
+use Spatie\Browsershot\Browsershot;
+
+class GeneratePdf implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        // reMarkable screen size: https://support.remarkable.com/hc/en-us/articles/360006699557
+        // original tablet pixel size / table dpi * browser dpi
+        // 1404 / 226 * 96
+        // 1872 / 226 * 96
+
+        Browsershot::url(url('/all'))
+            ->setExtraHttpHeaders(['X-Printing-Pdf' => 'true'])
+            ->showBackground()
+            ->paperSize(596, 795, 'px')
+            ->timeout(120)
+            ->save(Storage::path('planner.pdf'));
+    }
+}

--- a/app/Jobs/GeneratePdf.php
+++ b/app/Jobs/GeneratePdf.php
@@ -17,21 +17,6 @@ class GeneratePdf implements ShouldQueue
     use Queueable;
     use SerializesModels;
 
-    /**
-     * Create a new job instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        //
-    }
-
-    /**
-     * Execute the job.
-     *
-     * @return void
-     */
     public function handle()
     {
         // reMarkable screen size: https://support.remarkable.com/hc/en-us/articles/360006699557

--- a/resources/views/components/viewport.blade.php
+++ b/resources/views/components/viewport.blade.php
@@ -11,7 +11,7 @@
         </div>
     </div>
 
-    <form action="{{ route('generate-pdf')}}" method="post">
+    <form action="{{ route('generate-pdf') }}" method="post">
         @csrf
         <div class="flex justify-center">
             <button type="submit" class="px-5 py-3 text-white bg-black rounded-sm">Generate pdf</button>

--- a/resources/views/components/viewport.blade.php
+++ b/resources/views/components/viewport.blade.php
@@ -14,7 +14,7 @@
     <form action="{{ route('generate-pdf')}}" method="post">
         @csrf
         <div class="flex justify-center">
-            <button type="submit" class="px-5 py-3 text-white bg-black rounded-sm" >Generate pdf</button>
+            <button type="submit" class="px-5 py-3 text-white bg-black rounded-sm">Generate pdf</button>
         </div>
     </form>
 @endif

--- a/resources/views/components/viewport.blade.php
+++ b/resources/views/components/viewport.blade.php
@@ -10,4 +10,11 @@
             {{ $slot }}
         </div>
     </div>
+
+    <form action="{{ route('generate-pdf')}}" method="post">
+        @csrf
+        <div class="flex justify-center">
+            <button type="submit" class="px-5 py-3 text-white bg-black rounded-sm" >Generate pdf</button>
+        </div>
+    </form>
 @endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,3 +6,4 @@ Route::get('/all', 'App\Http\Controllers\PlannerController@all');
 Route::get('/tasks', 'App\Http\Controllers\PlannerController@tasks');
 Route::get('/{year?}', 'App\Http\Controllers\PlannerController@year');
 Route::get('/{year}/{month}/{day}', 'App\Http\Controllers\PlannerController@day');
+Route::post('/generate-pdf', 'App\Http\Controllers\GeneratePdfController')->name('generate-pdf');


### PR DESCRIPTION
This PR adds a `Generate PDF` button to the home page. The PDF gets generated and downloaded to the default download directory.

I had to change the folder where the pdf gets saved to from `storage` to `storage/app` to match the local disk path, that way we can force the browser to download the file.

<img width="744" alt="Screenshot 2022-09-27 at 17 31 24" src="https://user-images.githubusercontent.com/15965102/192583178-8b8c2242-f852-4d34-a320-4184c78d726b.png">
