### PR TITLE
Make year head full width

### DIFF
--- a/resources/views/components/viewport.blade.php
+++ b/resources/views/components/viewport.blade.php
@@ -1,12 +1,10 @@
 @if (request()->hasHeader('X-Printing-Pdf'))
     <div class="mx-auto break-before-page">
-        <div class="ml-[52px]">
-            {{ $slot }}
-        </div>
+        {{ $slot }}
     </div>
 @else
     <div class="w-[596px] h-[795px] overflow-hidden border border-black mx-auto my-4 break-before-page">
-        <div class="ml-[52px] h-full border-l border-black">
+        <div class="h-full border-l border-black">
             {{ $slot }}
         </div>
     </div>

--- a/resources/views/components/year.blade.php
+++ b/resources/views/components/year.blade.php
@@ -3,11 +3,11 @@
 <x-viewport>
     <a name="{{ $year->anchor() }}"></a>
 
-    <div class="p-2 mb-2 text-4xl text-center text-white bg-gray-900">
+    <div class="px-2 py-1.5 mb-2 text-4xl text-center text-white bg-gray-900">
         {{ $year->label() }}
     </div>
 
-    <div class="grid grid-cols-3 px-2 gap-x-2 gap-y-2">
+    <div class="ml-[52px] grid grid-cols-3 px-2 gap-x-2 gap-y-2">
         @foreach ($year->months() as $month)
             <div>
                 <div class="p-0.5 mb-1 text-xl text-center text-white bg-gray-800">


### PR DESCRIPTION
This PR makes the `year` header full width so that we don't have an ugly overlap when the sidebar is open.

![IMG_1879](https://user-images.githubusercontent.com/15965102/192590103-1d1937a9-2b27-4d2a-9eeb-1cd30ca0864a.jpg)
![IMG_1880](https://user-images.githubusercontent.com/15965102/192590111-b3c8c2c3-c5cb-4f4c-9a24-57b977b5aed8.jpg)
